### PR TITLE
Build with C++11 when not using MSVC

### DIFF
--- a/CMake/Bootstrap.cmake
+++ b/CMake/Bootstrap.cmake
@@ -21,7 +21,7 @@ if( NOT MSVC )
 	set( CMAKE_C_FLAGS_RELEASE			"${CMAKE_C_FLAGS_RELEASE}			-O2 -DNDEBUG"				)
 	set( CMAKE_C_FLAGS_RELWITHDEBINFO	"${CMAKE_C_FLAGS_RELWITHDEBINFO}	-O2 -g"						)
 
-	set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-overloaded-virtual" )
+	set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wno-overloaded-virtual" )
 endif()
 
 if( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )


### PR DESCRIPTION

When using gcc 12.2.0, this converts build errors to warnings. For example, the error from this output:
```
   In file included from Dependencies/FreeImage/Source/FreeImage/../OpenEXR/IlmImf/ImfHeader.h:51,
                    from Dependencies/FreeImage/Source/FreeImage/../OpenEXR/IlmImf/ImfOutputFile.h:46,
                    from Dependencies/FreeImage/Source/FreeImage/PluginEXR.cpp:33:
   Dependencies/FreeImage/Source/OpenEXR/Imath/ImathVec.h:228:41: error: ISO C++17 does not allow dynamic exception specifications
     228 |     const Vec2 &        normalizeExc () throw (IEX_NAMESPACE::MathExc);
         |
```
becomes:
```
   warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
```