### PR TITLE
Correctly set the p_numRefinements uniform for BC1 encoding

### DIFF
--- a/bin/Data/bc1.glsl
+++ b/bin/Data/bc1.glsl
@@ -7,7 +7,7 @@
 
 #define FLT_MAX 340282346638528859811704183484516925440.0f
 
-uniform uint p_numRefinements;
+layout( location = 0 ) uniform uint p_numRefinements;
 
 uniform sampler2D srcTex;
 


### PR DESCRIPTION
Set the uniform's location in the shader to match what's targeted by the `glUniform1ui` call.

Closes #9